### PR TITLE
Add Binary Search Tree Algorithm for Faster Searching

### DIFF
--- a/crt/kernel.c
+++ b/crt/kernel.c
@@ -991,7 +991,6 @@ kernel_mprotect(int pid, unsigned long addr, unsigned long len, int prot) {
                         sizeof(vm_map_entry_addr))) {
         return -1;
       }
-      vm_map_entry_addr = kernel_getlong(vm_map_entry_addr + 0);
     } else if(addr >= end) {
       // right
       if(kernel_copyout(vm_map_entry_addr + 0x18, &vm_map_entry_addr,


### PR DESCRIPTION
This PR adds a binary search tree (BST) algorithm. The root node is located at offset 0x1c8 in the vmspace, as mentioned in the [vm_map manual](https://man.freebsd.org/cgi/man.cgi?query=vm_map&sektion=9&apropos=0&manpath=FreeBSD+11-current).

After loading the `vm_map_entry_t`, you can start reading the left and right child nodes to perform quicker searches within the tree.

