### PR TITLE
Omit PIE when `-r` is present

### DIFF
--- a/host/bin/prospero-lld
+++ b/host/bin/prospero-lld
@@ -28,6 +28,9 @@ for ARG in "$@"; do
     if [[ "$ARG" == "--shared" ]]; then
 	PIE=""
     fi
+    if [[ "$ARG" == "-r" ]]; then
+	PIE=""
+    fi
     if [[ "$ARG" == "--static" ]]; then
 	PIE=""
     fi


### PR DESCRIPTION
The options are incompatible with each other. Ran into this when cross compiling some projects. Otherwise partial linking gets really tricky. The final executable should be position independent but I don't think the partially linked libraries need to be.

Feel free to correct me if I'm wrong, of course!