### PR TITLE
crt: fix `kernel_get_vmem_protection` return prot

### DIFF
--- a/crt/kernel.c
+++ b/crt/kernel.c
@@ -1400,8 +1400,7 @@ kernel_get_vmem_protection(int pid, unsigned long addr, unsigned long len) {
     if(prot < 0) {
       prot = vm_prot;
     } else if((prot & vm_prot) != prot) {
-      SET_ERRNO(EINVAL);
-      return -1;
+      break;
     }
 
     if(kernel_copyout(vm_entry + 0x08, &vm_entry, sizeof(vm_entry))) {


### PR DESCRIPTION
at least on xom process, like shellcore, this used to return -1 when querying on mapbase. haven't check on bc mode apps.
```c
dynlib_obj_t temp_obj = {};
kernel_dynlib_obj(pid, 0, &temp_obj);
start = temp_obj.mapbase;
start_size = temp_obj.mapsize;
prot = kernel_get_vmem_protection(pid, start, start_size); // returned -1
```
this changelist
```c
dynlib_obj_t temp_obj = {};
kernel_dynlib_obj(pid, 0, &temp_obj);
start = temp_obj.mapbase;
start_size = temp_obj.mapsize;
prot = kernel_get_vmem_protection(pid, start, start_size); // returned 4
```
