### PR TITLE
crt: fix kernel rw opreations

### DIFF
--- a/crt/kernel.c
+++ b/crt/kernel.c
@@ -39,6 +39,30 @@ along with this program; see the file COPYING. If not, see
 #define PROT_READ  1
 #define PROT_WRITE 2
 
+#define IN6_PKTINFOSZ 5 // (20/4)
+
+#pragma pack(4)
+typedef union kernel_pipe_buf {
+  unsigned int n[IN6_PKTINFOSZ];
+  struct f {
+    unsigned int cnt;
+    unsigned int in;
+    unsigned int out;
+    unsigned int reserved[2];
+  } flags;
+
+  struct b {
+    unsigned int size;
+    unsigned long buffer;
+    unsigned long reserved;
+  } pipe_buffer;
+
+  struct v {
+    unsigned long buffer;
+    unsigned int reserved[3];
+  } victim_buffer;
+} kernel_pipe_buf;
+#pragma pack()
 
 /**
  * public constants.
@@ -474,8 +498,8 @@ __kernel_init(payload_args_t* args) {
  * Write data to an address in kernel space.
  **/
 static int
-kernel_write(unsigned long addr, unsigned long *data) {
-  unsigned long victim_buf[3];
+kernel_write(unsigned long addr, void* data, unsigned long len) {
+  kernel_pipe_buf write_buf;
 
   // sanity check for invalid kernel pointers
   if(!(addr & 0xffff000000000000)) {
@@ -483,17 +507,18 @@ kernel_write(unsigned long addr, unsigned long *data) {
     return -1;
   }
 
-  victim_buf[0] = addr;
-  victim_buf[1] = 0;
-  victim_buf[2] = 0;
+  write_buf.victim_buffer.buffer = addr;
+  write_buf.victim_buffer.reserved[0] = 0;
+  write_buf.victim_buffer.reserved[1] = 0;
+  write_buf.victim_buffer.reserved[2] = 0;
 
   if(__crt_syscall(SYS_setsockopt, MASTER_SOCK, IPPROTO_IPV6, IPV6_PKTINFO,
-		   victim_buf, 0x14)) {
+		   &write_buf, sizeof(write_buf))) {
     return -1;
   }
 
   if(__crt_syscall(SYS_setsockopt, VICTIM_SOCK, IPPROTO_IPV6, IPV6_PKTINFO,
-		   data, 0x14)) {
+		   data, len)) {
     return -1;
   }
 
@@ -503,7 +528,7 @@ kernel_write(unsigned long addr, unsigned long *data) {
 
 int
 kernel_copyin(const void *uaddr, unsigned long kaddr, unsigned long len) {
-  unsigned long write_buf[3];
+  kernel_pipe_buf write_buf;
 
   if(!kaddr || !uaddr || !len) {
     SET_ERRNO(EINVAL);
@@ -511,18 +536,22 @@ kernel_copyin(const void *uaddr, unsigned long kaddr, unsigned long len) {
   }
 
   // Set pipe flags
-  write_buf[0] = 0;
-  write_buf[1] = 0x4000000000000000;
-  write_buf[2] = 0;
-  if(kernel_write(pipe_addr, (unsigned long *) &write_buf)) {
+  write_buf.flags.cnt = 0;
+  write_buf.flags.in = 0x40000000;
+  write_buf.flags.out = 0;
+  write_buf.flags.reserved[0] = 0; // set by next kernel_write
+  write_buf.flags.reserved[1] = 0; // set by next kernel_write
+
+  if(kernel_write(pipe_addr, &write_buf, sizeof(write_buf))) {
     return -1;
   }
 
   // Set pipe data addr
-  write_buf[0] = kaddr;
-  write_buf[1] = 0;
-  write_buf[2] = 0;
-  if(kernel_write(pipe_addr + 0x10, (unsigned long *) &write_buf)) {
+  write_buf.pipe_buffer.size = 0x40000000;
+  write_buf.pipe_buffer.buffer = kaddr;
+  write_buf.pipe_buffer.reserved = 0;
+
+  if(kernel_write(pipe_addr + 12, &write_buf, sizeof(write_buf))) {
     return -1;
   }
 
@@ -537,7 +566,7 @@ kernel_copyin(const void *uaddr, unsigned long kaddr, unsigned long len) {
 
 int
 kernel_copyout(unsigned long kaddr, void *uaddr, unsigned long len) {
-  unsigned long write_buf[3];
+  kernel_pipe_buf write_buf;
 
   if(!kaddr || !uaddr || !len) {
     SET_ERRNO(EINVAL);
@@ -545,18 +574,22 @@ kernel_copyout(unsigned long kaddr, void *uaddr, unsigned long len) {
   }
 
   // Set pipe flags
-  write_buf[0] = 0x4000000040000000;
-  write_buf[1] = 0x4000000000000000;
-  write_buf[2] = 0;
-  if(kernel_write(pipe_addr, (unsigned long *) &write_buf)) {
+  write_buf.flags.cnt = 0x40000000;
+  write_buf.flags.in = 0x40000000;
+  write_buf.flags.out = 0;
+  write_buf.flags.reserved[0] = 0; // set by next kernel_write
+  write_buf.flags.reserved[1] = 0; // set by next kernel_write
+
+  if(kernel_write(pipe_addr, &write_buf, sizeof(write_buf))) {
     return -1;
   }
 
   // Set pipe data addr
-  write_buf[0] = kaddr;
-  write_buf[1] = 0;
-  write_buf[2] = 0;
-  if(kernel_write(pipe_addr + 0x10, (unsigned long *) &write_buf)) {
+  write_buf.pipe_buffer.size = 0x40000000;
+  write_buf.pipe_buffer.buffer = kaddr;
+  write_buf.pipe_buffer.reserved = 0;
+
+  if(kernel_write(pipe_addr + 12, &write_buf, sizeof(write_buf))) {
     return -1;
   }
 

--- a/crt/kernel.c
+++ b/crt/kernel.c
@@ -536,10 +536,13 @@ kernel_copyin(const void *uaddr, unsigned long kaddr, unsigned long len) {
   }
 
   // Set pipe flags
+  // `write_buf.flags.reserved[0]` is set to not have an empty buffer
+  // https://github.com/PS5Dev/PS5SDK/blob/a2e03a2a0231a3a3397fa6cd087a01ca6d04f273/crt/kernel_helpers.c#L49
+  // https://github.com/freebsd/freebsd-src/blob/release/11.4.0/sys/netinet6/ip6_output.c#L2685
   write_buf.flags.cnt = 0;
-  write_buf.flags.in = 0x40000000;
+  write_buf.flags.in = 0;
   write_buf.flags.out = 0;
-  write_buf.flags.reserved[0] = 0; // set by next kernel_write
+  write_buf.flags.reserved[0] = 0x40000000; // set by next kernel_write
   write_buf.flags.reserved[1] = 0; // set by next kernel_write
 
   if(kernel_write(pipe_addr, &write_buf, sizeof(write_buf))) {
@@ -577,6 +580,8 @@ kernel_copyout(unsigned long kaddr, void *uaddr, unsigned long len) {
   write_buf.flags.cnt = 0x40000000;
   write_buf.flags.in = 0x40000000;
   write_buf.flags.out = 0;
+  // https://github.com/PS5Dev/PS5SDK/blob/a2e03a2a0231a3a3397fa6cd087a01ca6d04f273/crt/kernel_helpers.c#L70
+  // not required as cnt, in are already set, so there's some data in this buffer
   write_buf.flags.reserved[0] = 0; // set by next kernel_write
   write_buf.flags.reserved[1] = 0; // set by next kernel_write
 


### PR DESCRIPTION
- fixes writing at kernel address ending with `0xff` (see #56)

The sample test now passes:
```
prospero-deploy -h 192.168.1.28 -p 9021 hello_world.elf

Successfully read from address ending in 0xfe
Successfully read from address ending in 0xff
Successfully wrote to address ending in 0xfe
Successfully wrote to address ending in 0xff
```

- made pipe buf a union so it can't be typo by indexing

Thanks to @idlesauce for their assistance